### PR TITLE
changing package require name to make sense

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ This is a new library and requires extensive testing.  We are currently working 
 ## Setting up the client
 
 ```js
-var FuelNodeAuth = require( 'fuel-node-auth' );
+var FuelAuth = require( 'fuel-auth' );
 
 // Required Settings
 var myClientId     = 'yourClientId';
 var myClientSecret = 'yourClientSecret';
 
 // Minimal Initialization
-var FuelAuthClient = new FuelNodeAuth({
+var FuelAuthClient = new FuelAuth({
 	clientId: myClientId // required
 	, clientSecret: myClientSecret // required
 });
@@ -48,7 +48,7 @@ var accessToken  = ""; // Used with SSO - will be created for you if not provide
 var expiration   = ""; // Used with SSO - will be created for you if not provided
 var authUrl      = "https://auth.exacttargetapis.com/v1/requestToken"; //this is the default
 
-var FuelAuthClient = new FuelNodeAuth({
+var FuelAuthClient = new FuelAuth({
 	clientId: myClientId // required
 	, clientSecret: myClientSecret // required
 	, authUrl: authUrl

--- a/lib/fuel-auth.js
+++ b/lib/fuel-auth.js
@@ -4,12 +4,12 @@ var _            = require( 'lodash' );
 var EventEmitter = require( 'events' ).EventEmitter;
 var util         = require( 'util' );
 
-function FuelNodeAuth ( options ) {
+function FuelAuth ( options ) {
 	'use strict';
 
 	// returning instance if there already is one
-	if( !( this instanceof FuelNodeAuth ) ) {
-		return new FuelNodeAuth( options );
+	if( !( this instanceof FuelAuth ) ) {
+		return new FuelAuth( options );
 	}
 
 	//make sure clientId and clientSecret are available and not empty
@@ -31,9 +31,9 @@ function FuelNodeAuth ( options ) {
 }
 
 // adding inheriting properties from EventEmitter
-util.inherits( FuelNodeAuth, EventEmitter );
+util.inherits( FuelAuth, EventEmitter );
 
-FuelNodeAuth.prototype.getAccessToken = function( requestOptions, forceRequest, callback ) {
+FuelAuth.prototype.getAccessToken = function( requestOptions, forceRequest, callback ) {
 	'use strict';
 
 	if( this.checkExpired() || Boolean( forceRequest ) ) {
@@ -48,7 +48,7 @@ FuelNodeAuth.prototype.getAccessToken = function( requestOptions, forceRequest, 
 	}
 };
 
-FuelNodeAuth.prototype.checkExpired = function() {
+FuelAuth.prototype.checkExpired = function() {
 	'use strict';
 
 	// if current atomic time is equal or after exp, or we don't have a token, return true
@@ -59,7 +59,7 @@ FuelNodeAuth.prototype.checkExpired = function() {
 	}
 };
 
-FuelNodeAuth.prototype._requestToken = function( requestOptions, callback ) {
+FuelAuth.prototype._requestToken = function( requestOptions, callback ) {
 	'use strict';
 
 	// set auth options for request
@@ -101,7 +101,7 @@ FuelNodeAuth.prototype._requestToken = function( requestOptions, callback ) {
 	}.bind( this ) ); // binding function to FuelAuthClient so we can have a good context inside callback
 };
 
-FuelNodeAuth.prototype._deliverResponse = function( type, data, callback ) {
+FuelAuth.prototype._deliverResponse = function( type, data, callback ) {
 	'use strict';
 
 	// if it's a callback, lets use that
@@ -118,4 +118,4 @@ FuelNodeAuth.prototype._deliverResponse = function( type, data, callback ) {
 };
 
 // exporting module
-module.exports = FuelNodeAuth;
+module.exports = FuelAuth;

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "fuel-node-auth",
+  "name": "fuel-auth",
   "version": "0.2.0",
   "description": "Node Library for Authenticating with ExactTarget Fuel. Used for authenticating REST and SOAP APIs.",
-  "main": "./lib/fuel-node-auth.js",
+  "main": "./lib/fuel-auth.js",
   "scripts": {
     "test": "grunt jshint && mocha --reporter=spec test/spec"
   },

--- a/test/spec/fuel-node-auth-test.js
+++ b/test/spec/fuel-node-auth-test.js
@@ -1,6 +1,6 @@
-var should       = require( 'should' );
-var app          = require( '../app' );
-var FuelNodeAuth = require( '../../lib/fuel-node-auth' );
+var should   = require( 'should' );
+var app      = require( '../app' );
+var FuelAuth = require( '../../lib/fuel-auth' );
 
 /*
 ======== ShouldJS Reference ========
@@ -11,14 +11,14 @@ Docs ref for Shouldjs - https://github.com/shouldjs/should.js
 */
 
 var server;
-var client = new FuelNodeAuth({
+var client = new FuelAuth({
 	"authUrl" : "http://localhost:3000/auth",
 	"clientId" : '12345',
 	"clientSecret" : '12345'
 });
 
 
-describe('FuelNodeAuth', function () {
+describe('FuelAuth', function () {
 	// before(function(){
 	// 	server = app.listen(3000);
 	// });


### PR DESCRIPTION
since people will only be using this in node, seemed redundant to have the require be "fuel-node-auth". Changing the require to be 'fuel-auth'
