### PR TITLE
The fuel token routes support an optional scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ This is a new library and requires extensive testing. Feel free to test it out a
 		* clientSecret - required
 		* authUrl - not required
 			* default: https://auth.exacttargetapis.com/v1/requestToken
+		* scope - not required
+			* can be used to set a client context when a refreshToken is not available
 
 ## API
 

--- a/lib/fuel-auth.js
+++ b/lib/fuel-auth.js
@@ -126,7 +126,7 @@ FuelAuth.prototype._requestToken = function( requestOptions, callback ) {
 	} else if ( this.scope ) {
 		// adding scope to json if it's there
 		// it's not valid to use both scope and a refresh token
-		options.json.scope = this.scope
+		options.json.scope = this.scope;
 	}
 
 	// sending request to API


### PR DESCRIPTION
Adding an option for scope when using this library. I did not add it to the documentation as use of this may not be encouraged (?) but it is still required in certain cases.
